### PR TITLE
Feature/quick notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ daily block "Waiting for AWS access" --tags aws
 # Log a meeting
 daily meeting "Sprint planning" --tags team
 
+# Add a quick note
+daily quick "Check new API documentation" --tags api
+
 # Show cheat sheet for standup
 daily cheat
 ```
@@ -120,6 +123,7 @@ daily cheat
 | `daily plan "text"` | Plan work for today | To Do |
 | `daily block "text"` | Log a blocker | Blockers |
 | `daily meeting "text"` | Log a meeting | Meetings |
+| `daily quick "text"` | Add a quick note | Quick Notes |
 | `daily cheat` | Show standup cheat sheet | - |
 | `daily search` | Search and open daily files | - |
 
@@ -149,6 +153,9 @@ TO DO
 
 BLOCKERS
 - Waiting for AWS access
+
+QUICK NOTES
+- Check new API documentation
 ```
 
 ### Options

--- a/daily/cli.py
+++ b/daily/cli.py
@@ -125,6 +125,23 @@ def meeting(
 
 
 @app.command()
+def quick(
+    text: str = typer.Argument(..., help="Quick note"),
+    tags: str = typer.Option(None, "--tags", "-t", help="Comma-separated tags"),
+) -> None:
+    """Add quick note (Quick Notes section)."""
+    text = validate_text(text)
+    tag_list = parse_tags(tags)
+
+    insert_bullet("notes", text, tags=tag_list)
+
+    if tag_list:
+        typer.echo(f"✓ Added to Quick Notes: {text} #tags: {','.join(tag_list)}")
+    else:
+        typer.echo(f"✓ Added to Quick Notes: {text}")
+
+
+@app.command()
 def cheat(
     tags: str = typer.Option(None, "--tags", "-t", help="Filter by tags"),
     plain: bool = typer.Option(
@@ -209,6 +226,7 @@ def _print_cheat_rich(data: list[dict], date=None) -> None:
         "meeting": ("bold blue", "🗓"),
         "plan": ("bold yellow", "▶️"),
         "block": ("bold red", "🚧"),
+        "notes": ("bold magenta", "🧠"),
     }
 
     # Show which date we're reading

--- a/daily/core.py
+++ b/daily/core.py
@@ -266,6 +266,7 @@ def generate_cheat_data(
         ("MEETINGS", "meeting"),
         ("TO DO", "plan"),
         ("BLOCKERS", "block"),
+        ("QUICK NOTES", "notes"),
     ]
 
     result = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daily-cli-tool"
-version = "1.0.0"
+version = "1.1.0"
 description = "Minimalist CLI for engineers to log daily work"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -387,7 +387,7 @@ class TestGenerateCheat:
             generate_cheat(date=date)
 
     def test_generate_cheat_includes_meetings(self, temp_dailies_dir):
-        """Includes Done, Meetings, To Do, Blockers (not Notes)."""
+        """Includes Done, Meetings, To Do, Blockers, and Quick Notes."""
         date = datetime(2026, 1, 26)
         insert_bullet("did", "Task", date=date)
         insert_bullet("meeting", "Important meeting", date=date)
@@ -399,6 +399,7 @@ class TestGenerateCheat:
         assert "MEETINGS" in cheat
         assert "TO DO" in cheat
         assert "BLOCKERS" in cheat
+        assert "QUICK NOTES" in cheat
         assert "Important meeting" in cheat
-        # Quick notes are not included in cheat
-        assert "Quick note" not in cheat
+        # Quick notes are now included in cheat
+        assert "Quick note" in cheat

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ toml = [
 ]
 
 [[package]]
-name = "daily-cli"
+name = "daily-cli-tool"
 version = "1.0.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- Add new `daily quick` command to add quick notes
- Quick notes now appear in `daily cheat` output
- Version bumped to 1.1.0 (minor version for new feature)

## Changes
- **New command**: `daily quick "note text" --tags tag1,tag2`
- **Cheat sheet**: Quick Notes section now displayed with 🧠 icon
- **Tests**: Updated test to reflect new behavior (all 143 tests passing)
- **Documentation**: Updated README with examples and command table