### PR TITLE
fix: Add UTF-8 encoding support for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ dailies/
 
 # Internal docs (not for public repo)
 .python-version
+
+# Vagrant testing infrastructure
+vagrant-test/

--- a/daily/cli.py
+++ b/daily/cli.py
@@ -15,6 +15,27 @@ from daily.core import (
     list_daily_files,
 )
 
+
+def _fix_windows_console_encoding() -> None:
+    """Fix console encoding on Windows to support UTF-8/emojis.
+
+    On Windows, the default console encoding is often cp1252 or similar,
+    which doesn't support emojis and Unicode characters. This function
+    reconfigures stdout and stderr to use UTF-8 encoding.
+
+    This is only applied on Windows systems and is safe to call on other platforms.
+    """
+    if sys.platform == "win32":
+        # Reconfigure stdout and stderr to use UTF-8 encoding
+        if sys.stdout is not None and hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(encoding="utf-8")
+        if sys.stderr is not None and hasattr(sys.stderr, "reconfigure"):
+            sys.stderr.reconfigure(encoding="utf-8")
+
+
+# Fix encoding issues on Windows before creating Console
+_fix_windows_console_encoding()
+
 console = Console()
 
 app = typer.Typer(

--- a/daily/config.py
+++ b/daily/config.py
@@ -97,4 +97,4 @@ def create_default_config() -> None:
 # You can use ~ for user's home directory
 dailies_dir = "{DEFAULT_DAILIES_DIR}"
 '''
-        CONFIG_FILE.write_text(default_config)
+        CONFIG_FILE.write_text(default_config, encoding="utf-8")

--- a/daily/core.py
+++ b/daily/core.py
@@ -82,7 +82,7 @@ def ensure_daily_file_exists(date: datetime | None = None) -> Path:
 
     if not file_path.exists():
         template = create_daily_template(date)
-        file_path.write_text(template)
+        file_path.write_text(template, encoding="utf-8")
 
     return file_path
 
@@ -104,7 +104,7 @@ def read_daily_file(date: datetime | None = None) -> str:
     if not file_path.exists():
         raise FileNotFoundError(f"No daily file exists for {file_path.name}")
 
-    return file_path.read_text()
+    return file_path.read_text(encoding="utf-8")
 
 
 def write_daily_file(content: str, date: datetime | None = None) -> Path:
@@ -118,7 +118,7 @@ def write_daily_file(content: str, date: datetime | None = None) -> Path:
         Path to the saved file.
     """
     file_path = get_daily_file_path(date)
-    file_path.write_text(content)
+    file_path.write_text(content, encoding="utf-8")
     return file_path
 
 
@@ -313,7 +313,7 @@ def list_daily_files(
 
             # If tags filter is specified, check if file contains any of the tags
             if filter_tags:
-                content = file_path.read_text()
+                content = file_path.read_text(encoding="utf-8")
                 # Check if ANY bullet in the file has at least one of the tags
                 has_matching_bullet = False
                 for section_title in SECTIONS.values():
@@ -347,7 +347,7 @@ def get_all_tags_from_file(file_path: Path) -> set[str]:
         Set of unique tags found in the file.
     """
     try:
-        content = file_path.read_text()
+        content = file_path.read_text(encoding="utf-8")
         all_tags = set()
 
         for section_title in SECTIONS.values():

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ toml = [
 
 [[package]]
 name = "daily-cli-tool"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "iterfzf" },


### PR DESCRIPTION
## Summary
Fixes #1 - Windows encoding issue

This PR adds proper UTF-8 encoding support for Windows systems, eliminating the need for users to manually set the `PYTHONUTF8=1` environment variable.

## Problem
On Windows, the default console encoding (cp1252) doesn't support emojis and Unicode characters used throughout the CLI (✅, 🧠, ▶️, 🚧, 🗓). This caused:
- `UnicodeEncodeError` when printing to console
- `ValueError: Section '## Done' not found` when creating files (emojis in section headers were corrupted)

## Solution
The fix addresses encoding issues in three areas:

1. **Console Output**: Reconfigure stdout/stderr to use UTF-8 on Windows
   - Only applies on Windows (`sys.platform == "win32"`)
   - Safe to call on all platforms

2. **File Writing**: Explicitly use UTF-8 encoding for all file operations
   - Daily files (`.write_text(content, encoding='utf-8')`)
   - Config files

3. **File Reading**: Explicitly use UTF-8 encoding when reading files
   - Ensures consistency across platforms

## Testing
- ✅ Tested on Windows 11 with Python 3.12 (via Vagrant VM)
- ✅ Tested on Linux with Python 3.12
- ✅ All 143 tests passing
- ✅ Verified emojis render correctly on Windows without PYTHONUTF8

## Changes
- `daily/cli.py`: Add `_fix_windows_console_encoding()` function
- `daily/core.py`: Add explicit UTF-8 encoding to all file operations
- `daily/config.py`: Add explicit UTF-8 encoding to config file creation
- `.gitignore`: Ignore vagrant-test directory

## Before/After
**Before (Windows):**
```powershell
> daily did "Test ✅"
UnicodeEncodeError: 'charmap' codec can't encode character '\u2705'
```

**After (Windows):**
```powershell
> daily did "Test ✅"
✓ Added to Done: Test ✅
```